### PR TITLE
Improved the syntax of the EventDeclaration and the Reaction

### DIFF
--- a/Example-project/src/main/java/core/Example.eketal
+++ b/Example-project/src/main/java/core/Example.eketal
@@ -20,7 +20,13 @@ eventclass Example{
 		localhost
 	}
 	
-	event eventoHello():host(localGroup)&&call(core.HelloWorld.helloMethod());
+	event eventoHello():host(localGroup)&&call(* core.HelloWorld.helloMethod());
 	
-	event eventoWorld(): call(core.HelloWorld.worldMethod());
+	event eventoWorld(): call(* core.HelloWorld.worldMethod());
+	
+	reaction before automatonConstructor.firstState{
+		
+		
+	}
+	
 }

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal.ui/src/co/edu/icesi/eketal/ui/wizard/EketalNewProjectWizardInitialContents.xtend
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal.ui/src/co/edu/icesi/eketal/ui/wizard/EketalNewProjectWizardInitialContents.xtend
@@ -43,6 +43,12 @@ class EketalNewProjectWizardInitialContents {
 				event eventoHello():host(localGroup)&&call(core.HelloWorld.helloMethod());
 				
 				event eventoWorld(): call(core.HelloWorld.worldMethod());
+				
+				reaction before automatonConstructor.firstState{
+					
+					
+				}
+				
 			}
 			'''
 		)

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/model/generated/Eketal.ecore
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/model/generated/Eketal.ecore
@@ -97,6 +97,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="Rc" eSuperTypes="#//Decl">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="syncex" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="pos" eType="#//Pos"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="automaton" eType="#//Automaton"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="state" eType="#//Step"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="body" eType="#//Body" containment="true"/>
   </eClassifiers>

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/model/generated/Eketal.ecore
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/model/generated/Eketal.ecore
@@ -13,14 +13,14 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="declarations" upperBound="-1"
         eType="#//Decl" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="Decl">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="Decl"/>
   <eClassifiers xsi:type="ecore:EClass" name="JVarD" eSuperTypes="#//Decl">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="type" eType="ecore:EClass platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.ecore#//JvmTypeReference"
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="MSig" eSuperTypes="#//Decl">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="params" upperBound="-1"
         eType="ecore:EClass platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.ecore#//JvmFormalParameter"
         containment="true"/>
@@ -30,6 +30,7 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="EvDecl" eSuperTypes="#//Decl">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="params" upperBound="-1"
         eType="ecore:EClass platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.ecore#//JvmFormalParameter"
         containment="true"/>
@@ -49,12 +50,20 @@
         containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Trigger" eSuperTypes="#//EventPredicate">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="returndef" eType="#//JVMTYPE"
+        containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="esig" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="params" upperBound="-1"
         eType="ecore:EClass platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.ecore#//JvmTypeReference"
         containment="true"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="JVMTYPE">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="astk" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="jvmRef" eType="ecore:EClass platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.ecore#//JvmTypeReference"
+        containment="true"/>
+  </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Group" eSuperTypes="#//Decl">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="hosts" upperBound="-1"
         eType="#//Host" containment="true"/>
   </eClassifiers>
@@ -63,6 +72,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="groupId" eType="#//Group"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Automaton" eSuperTypes="#//Decl">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="params" upperBound="-1"
         eType="ecore:EClass platform:/resource/org.eclipse.xtext.common.types/model/JavaVMTypes.ecore#//JvmFormalParameter"
         containment="true"/>
@@ -87,6 +97,7 @@
   <eClassifiers xsi:type="ecore:EClass" name="Rc" eSuperTypes="#//Decl">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="syncex" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="pos" eType="#//Pos"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="state" eType="#//Step"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="body" eType="#//Body" containment="true"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EEnum" name="Pos">
@@ -97,7 +108,6 @@
   <eClassifiers xsi:type="ecore:EClass" name="Body">
     <eStructuralFeatures xsi:type="ecore:EReference" name="body" eType="ecore:EClass platform:/resource/org.eclipse.xtext.xbase/model/Xbase.ecore#//XExpression"
         containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="grupo" eType="#//Group"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="OrEvent" eSuperTypes="#//EventExpression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="left" eType="#//EventExpression"

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/model/generated/Eketal.genmodel
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/model/generated/Eketal.genmodel
@@ -85,6 +85,7 @@
     <genClasses ecoreClass="Eketal.ecore#//Rc">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//Rc/syncex"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//Rc/pos"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Eketal.ecore#//Rc/automaton"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Eketal.ecore#//Rc/state"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//Rc/body"/>
     </genClasses>

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/model/generated/Eketal.genmodel
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/model/generated/Eketal.genmodel
@@ -25,18 +25,19 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//EventClass/name"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//EventClass/declarations"/>
     </genClasses>
-    <genClasses ecoreClass="Eketal.ecore#//Decl">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//Decl/name"/>
-    </genClasses>
+    <genClasses ecoreClass="Eketal.ecore#//Decl"/>
     <genClasses ecoreClass="Eketal.ecore#//JVarD">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//JVarD/name"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//JVarD/type"/>
     </genClasses>
     <genClasses ecoreClass="Eketal.ecore#//MSig">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//MSig/name"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//MSig/params"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//MSig/type"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//MSig/body"/>
     </genClasses>
     <genClasses ecoreClass="Eketal.ecore#//EvDecl">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//EvDecl/name"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//EvDecl/params"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//EvDecl/eventos"/>
     </genClasses>
@@ -51,10 +52,16 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//KindAttribute/condition"/>
     </genClasses>
     <genClasses ecoreClass="Eketal.ecore#//Trigger">
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//Trigger/returndef"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//Trigger/esig"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//Trigger/params"/>
     </genClasses>
+    <genClasses ecoreClass="Eketal.ecore#//JVMTYPE">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//JVMTYPE/astk"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//JVMTYPE/jvmRef"/>
+    </genClasses>
     <genClasses ecoreClass="Eketal.ecore#//Group">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//Group/name"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//Group/hosts"/>
     </genClasses>
     <genClasses ecoreClass="Eketal.ecore#//Host">
@@ -62,6 +69,7 @@
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Eketal.ecore#//Host/groupId"/>
     </genClasses>
     <genClasses ecoreClass="Eketal.ecore#//Automaton">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//Automaton/name"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//Automaton/params"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//Automaton/steps"/>
     </genClasses>
@@ -77,11 +85,11 @@
     <genClasses ecoreClass="Eketal.ecore#//Rc">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//Rc/syncex"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute Eketal.ecore#//Rc/pos"/>
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Eketal.ecore#//Rc/state"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//Rc/body"/>
     </genClasses>
     <genClasses ecoreClass="Eketal.ecore#//Body">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//Body/body"/>
-      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference Eketal.ecore#//Body/grupo"/>
     </genClasses>
     <genClasses ecoreClass="Eketal.ecore#//OrEvent">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference Eketal.ecore#//OrEvent/left"/>

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/Eketal.xtext
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/Eketal.xtext
@@ -14,7 +14,7 @@ generate eketal "http://www.icesi.edu.co/eketal/Eketal"
 Model:
 	('package' name = QualifiedName ->';'?)?
 	importSection = XImportSection?
-	typeDeclaration = EventClass?//TODO por qué está con el ?
+	typeDeclaration = EventClass?
 ;
 
 EventClass:
@@ -80,10 +80,17 @@ KindAttribute:
 //	| 'eq'"("JExp","JExp")"
 ;
 
-//TODO permitir que haya un tipo de dato antes del qualified name
 Trigger:
-	'call''('esig=QualifiedName'('(params+=JvmTypeReference 
-		(',' params+=JvmTypeReference)* )?')'')'//funciona 
+	'call' '(' returndef=TypeReturn esig=QualifiedName'('(params+=JvmTypeReference 
+		(',' params+=JvmTypeReference)* )?')'')'
+;
+
+TypeReturn returns JVMTYPE:
+	astk=ANY | jvmRef=JvmTypeReference
+;
+
+terminal ANY:
+	'*'
 ;
 
 Group:
@@ -103,8 +110,7 @@ Ip:
 //////////////////////////////////////
 ////Automata definicion
 //////////////////////////////////////
-//TODO Tiene que haber una verificación de si, es un estado inicial (contiene la palabra start)
-//debe tener transiciones, porque sino, no se puede llegar a ningún lado
+//TODO el estado inicial debe tener transiciones, porque sino, no se puede llegar a ningún lado
 //TODO estado de finalización default
 //TODO Restricción de que solo puede haber un autómata
 Automaton:
@@ -130,7 +136,16 @@ enum StateType:
 ////Reaction definition
 //////////////////////////////////////
 Rc:
-	(syncex="syncex")? 'reaction' pos=Pos name=ID '{' body=Body '}'
+	(syncex="syncex")? 'reaction' pos=Pos (state=[Step|QFN]) body=Body
+//	(syncex="syncex")? 'reaction' pos=Pos name=QFN body=Body //TODO Automaton.Step
+;
+
+//https://github.com/unicesi/pascani/blob/master/plugins/org.pascani.dsl/src/org/pascani/dsl/scoping/PascaniScopeProvider.xtend
+//https://github.com/unicesi/pascani/blob/master/plugins/org.pascani.dsl/src/org/pascani/dsl/runtime/PascaniQualifiedNameProvider.xtend
+//https://github.com/unicesi/pascani/blob/master/plugins/org.pascani.dsl/src/org/pascani/dsl/Pascani.xtext
+//https://github.com/unicesi/pascani/blob/master/plugins/org.pascani.dsl/src/org/pascani/dsl/PascaniRuntimeModule.xtend
+QFN:
+    ID ('.' ID)*
 ;
 
 enum Pos:
@@ -138,5 +153,6 @@ enum Pos:
 ;
 
 Body:
-	body=XBlockExpression | 'addGroup' '('grupo=[Group]')' | 'removeGroup' '('grupo=[Group]')'
+	body=XBlockExpression
+//	body=XBlockExpression | 'addGroup' '('grupo=[Group]')' | 'removeGroup' '('grupo=[Group]')'
 ;

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/Eketal.xtext
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/Eketal.xtext
@@ -136,17 +136,13 @@ enum StateType:
 ////Reaction definition
 //////////////////////////////////////
 Rc:
-	(syncex="syncex")? 'reaction' pos=Pos (state=[Step|QFN]) body=Body
-//	(syncex="syncex")? 'reaction' pos=Pos name=QFN body=Body //TODO Automaton.Step
+	(syncex="syncex")? 'reaction' pos=Pos automaton=[Automaton]'.'state=[Step] body=Body
+//	(syncex="syncex")? 'reaction' pos=Pos (state=[Step|QFN]) body=Body//This implementations works with the fully qualifiedname, so the program suggested all the name (package.eventclass.automaton.step) instead of only automaton.step
 ;
 
-//https://github.com/unicesi/pascani/blob/master/plugins/org.pascani.dsl/src/org/pascani/dsl/scoping/PascaniScopeProvider.xtend
-//https://github.com/unicesi/pascani/blob/master/plugins/org.pascani.dsl/src/org/pascani/dsl/runtime/PascaniQualifiedNameProvider.xtend
-//https://github.com/unicesi/pascani/blob/master/plugins/org.pascani.dsl/src/org/pascani/dsl/Pascani.xtext
-//https://github.com/unicesi/pascani/blob/master/plugins/org.pascani.dsl/src/org/pascani/dsl/PascaniRuntimeModule.xtend
-QFN:
-    ID ('.' ID)*
-;
+//QFN:
+//    ID ('.' ID)*
+//;
 
 enum Pos:
 	before | around | after

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/EketalRuntimeModule.xtend
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/EketalRuntimeModule.xtend
@@ -10,11 +10,21 @@ import org.eclipse.xtext.xbase.scoping.batch.ImplicitlyImportedFeatures
 import co.edu.icesi.eketal.outputconfiguration.EketalOutputConfigurationProvider
 import org.eclipse.xtext.generator.IGenerator
 import co.edu.icesi.eketal.outputconfiguration.OutputConfigurationAwaredGenerator
+import co.edu.icesi.eketal.scoping.EketalScopeProvider
+import org.eclipse.xtext.scoping.IScopeProvider
+import org.eclipse.xtext.linking.LinkingScopeProviderBinding
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
  */
 class EketalRuntimeModule extends AbstractEketalRuntimeModule {
+	
+	override void configureLinkingIScopeProvider(Binder binder) {
+		binder
+			.bind(IScopeProvider)
+			.annotatedWith(LinkingScopeProviderBinding)
+			.to(EketalScopeProvider);
+	}
 	
 	override void configure(Binder binder) {
 		super.configure(binder)
@@ -30,5 +40,9 @@ class EketalRuntimeModule extends AbstractEketalRuntimeModule {
 	override Class<? extends IGenerator> bindIGenerator() {
 		return OutputConfigurationAwaredGenerator
 	}
+	
+	override Class<? extends IScopeProvider> bindIScopeProvider() {
+		return EketalScopeProvider
+	} 
 	
 }

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/generator/EketalGenerator.xtend
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/generator/EketalGenerator.xtend
@@ -226,12 +226,21 @@ class EketalGenerator implements IGenerator{
 		for(p : trigger.params){
 			parameters+=p.simpleName
 		}
+		
+		var String typeReturn = null
+		if(trigger.returndef.astk==null){
+			typeReturn=trigger.returndef.jvmRef.simpleName
+		}else{
+			typeReturn = "*"
+		}
+		
 		/*
 		 * La primera posición es el nombre del pointcut, la segunda es la definición del pointcut completo
 		 * En el pointcut completo se toma todos los parámetros y agrupan separados por ','
 		 */
+		 
 		var CharSequence[] returnCall = newArrayList('''point«trigger.esig.toString.replaceAll("\\.", "").toFirstUpper»()''',
-			'''pointcut point«trigger.esig.toString.replaceAll("\\.", "").toFirstUpper»(): call(* «trigger.esig»(«parameters.join(',')»))''')
+			'''pointcut point«trigger.esig.toString.replaceAll("\\.", "").toFirstUpper»(): call(«typeReturn» «trigger.esig»(«parameters.join(',')»))''')
 		return returnCall
 	}
 	

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/scoping/EketalScopeProvider.xtend
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/scoping/EketalScopeProvider.xtend
@@ -5,11 +5,12 @@ package co.edu.icesi.eketal.scoping
 
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EReference
-import co.edu.icesi.eketal.eketal.Rc
 import co.edu.icesi.eketal.eketal.EketalPackage
 import org.eclipse.xtext.EcoreUtil2
 import co.edu.icesi.eketal.eketal.Step
 import org.eclipse.xtext.scoping.Scopes
+import org.eclipse.xtext.scoping.IScope
+import co.edu.icesi.eketal.eketal.Rc
 
 /**
  * This class contains custom scoping description.
@@ -19,14 +20,18 @@ import org.eclipse.xtext.scoping.Scopes
  */
 class EketalScopeProvider extends AbstractEketalScopeProvider {
 	
-//	override getScope(EObject context, EReference reference) {
-//		if (context instanceof Rc) {
-//			if (reference == EketalPackage.Literals.AUTOMATON__STEPS && context.state != null) {
-//				val candidates = EcoreUtil2.getAllContentsOfType(context.state, Step);
-//				return Scopes.scopeFor(candidates)
-//			}
-//		}
-//		return super.getScope(context, reference);
+//	def IScope scopeReaction(Rc reaction, EReference ref){
+//		return Scopes.scopeFor(reaction.automaton.steps)
 //	}
+	
+	override getScope(EObject context, EReference reference) {
+		if (context instanceof Rc) {
+			if (reference == EketalPackage.Literals.RC__STATE) {
+				val candidates = context.automaton.steps
+				return Scopes.scopeFor(candidates)
+			}
+		}
+		return super.getScope(context, reference);
+	}
 	
 }

--- a/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/scoping/EketalScopeProvider.xtend
+++ b/co.edu.icesi.eketal.parent-master/co.edu.icesi.eketal/src/co/edu/icesi/eketal/scoping/EketalScopeProvider.xtend
@@ -3,6 +3,13 @@
  */
 package co.edu.icesi.eketal.scoping
 
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.EReference
+import co.edu.icesi.eketal.eketal.Rc
+import co.edu.icesi.eketal.eketal.EketalPackage
+import org.eclipse.xtext.EcoreUtil2
+import co.edu.icesi.eketal.eketal.Step
+import org.eclipse.xtext.scoping.Scopes
 
 /**
  * This class contains custom scoping description.
@@ -11,5 +18,15 @@ package co.edu.icesi.eketal.scoping
  * on how and when to use it.
  */
 class EketalScopeProvider extends AbstractEketalScopeProvider {
-
+	
+//	override getScope(EObject context, EReference reference) {
+//		if (context instanceof Rc) {
+//			if (reference == EketalPackage.Literals.AUTOMATON__STEPS && context.state != null) {
+//				val candidates = EcoreUtil2.getAllContentsOfType(context.state, Step);
+//				return Scopes.scopeFor(candidates)
+//			}
+//		}
+//		return super.getScope(context, reference);
+//	}
+	
 }


### PR DESCRIPTION
First the EventDeclaration in the grammar did not allow to select the return type for the calls of the methods (Trigger rule).
As we can see in the following lines, the first was generic, but the second one, allows to changes the return type for the call
    event eventoHello():host(localGroup)&&call(core.HelloWorld.helloMethod()); //before
    event eventoHello():host(localGroup)&&call(\* core.HelloWorld.helloMethod()); //after
Second main change was to instance a Step inside a Reaction declaration, and was solve in this [issue](https://github.com/unicesi/eketal/issues/16). More detailed information can be found in that issue
